### PR TITLE
Supports absolute path as the "baseDir"

### DIFF
--- a/src/createTeardown.test.ts
+++ b/src/createTeardown.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import * as path from 'path'
 import { createTeardown, addFile, addDirectory } from './createTeardown'
 
 const BASE_DIR = './tmp'
@@ -146,6 +147,19 @@ test('removes a given file', async () => {
   removeFile('remove-file/two.txt')
   expect(fs.existsSync(getPath('remove-file/two.txt'))).toBe(false)
   expect(fs.existsSync(getPath('remove-file/one.txt'))).toBe(true)
+
+  await cleanup()
+})
+
+test('supports absolute "baseDir" path', async () => {
+  const absolutePath = path.resolve(__dirname, 'tmp')
+  const { prepare, getPath, cleanup } = createTeardown(
+    absolutePath,
+    addFile('file.txt'),
+  )
+  await prepare()
+
+  expect(fs.existsSync(getPath('file.txt'))).toBe(true)
 
   await cleanup()
 })

--- a/src/createTeardown.ts
+++ b/src/createTeardown.ts
@@ -68,7 +68,9 @@ export function createTeardown(
   baseDir: string,
   ...operations: TeardownOperation[]
 ): TeardownControls {
-  const absoluteBaseDir = path.resolve(process.cwd(), baseDir)
+  const absoluteBaseDir = path.isAbsolute(baseDir)
+    ? baseDir
+    : path.resolve(process.cwd(), baseDir)
 
   const api: TeardownControls = {
     prepare() {


### PR DESCRIPTION
## Previously

Couldn't provide an absolute path to `createTeardown`, it would always resolve it against the CWD.

## Now

Can provide an absolute path. Relative paths will still be resolved against CWD. 