### PR TITLE
refactor(read): rename to "readFile", throw on non-existing paths

### DIFF
--- a/src/fsTeardown.ts
+++ b/src/fsTeardown.ts
@@ -126,6 +126,13 @@ export function fsTeardown(options: TeardownOptions): TeardownApi {
     async readFile(...args: Parameters<TeardownApi['readFile']>) {
       const [filePath, encoding] = args
       const absolutePath = api.resolve(filePath)
+
+      invariant(
+        fs.existsSync(absolutePath),
+        'Failed to read a file at "%s": given path does not exist.',
+        filePath,
+      )
+
       const stats = fs.statSync(absolutePath)
 
       invariant(

--- a/src/fsTeardown.ts
+++ b/src/fsTeardown.ts
@@ -22,8 +22,8 @@ export interface TeardownApi {
   /**
    * Reads a file at the given path.
    */
-  read(filePath: string): Promise<Buffer>
-  read(filePath: string, encoding?: BufferEncoding): Promise<string>
+  readFile(filePath: string): Promise<Buffer>
+  readFile(filePath: string, encoding?: BufferEncoding): Promise<string>
 
   /**
    * Edits a file at the given path.
@@ -123,7 +123,7 @@ export function fsTeardown(options: TeardownOptions): TeardownApi {
       await emitTree(tree, rootDir)
     },
 
-    async read(...args: Parameters<TeardownApi['read']>) {
+    async readFile(...args: Parameters<TeardownApi['readFile']>) {
       const [filePath, encoding] = args
       const absolutePath = api.resolve(filePath)
       const stats = fs.statSync(absolutePath)

--- a/test/constructor.test.ts
+++ b/test/constructor.test.ts
@@ -27,11 +27,11 @@ afterAll(async () => {
 })
 
 it('creates an empty file', async () => {
-  expect(await api.read('empty.txt', 'utf8')).toEqual('')
+  expect(await api.readFile('empty.txt', 'utf8')).toEqual('')
 })
 
 it('creates a text file', async () => {
-  expect(await api.read('text.txt', 'utf8')).toEqual('hello world')
+  expect(await api.readFile('text.txt', 'utf8')).toEqual('hello world')
 })
 
 it('creates an empty directory', async () => {
@@ -41,18 +41,20 @@ it('creates an empty directory', async () => {
 it('creates directory with files', async () => {
   expect(isDirectory(api.resolve('dir-nested'))).toEqual(true)
 
-  expect(await api.read('dir-nested/one.txt', 'utf8')).toEqual('first')
-  expect(await api.read('dir-nested/two.txt', 'utf8')).toEqual('second')
+  expect(await api.readFile('dir-nested/one.txt', 'utf8')).toEqual('first')
+  expect(await api.readFile('dir-nested/two.txt', 'utf8')).toEqual('second')
 })
 
 it('creates a deeply nested directory with files', async () => {
   expect(isDirectory(api.resolve('dir-deeply/nested/directory'))).toEqual(true)
   expect(
-    await api.read('dir-deeply/nested/directory/with-file.txt', 'utf8'),
+    await api.readFile('dir-deeply/nested/directory/with-file.txt', 'utf8'),
   ).toEqual('yes')
 })
 
 it('creates a deeply nested file', async () => {
   expect(isDirectory(api.resolve('dir-deeply/nested'))).toEqual(true)
-  expect(await api.read('dir-deeply/nested/file.txt', 'utf8')).toEqual('yes')
+  expect(await api.readFile('dir-deeply/nested/file.txt', 'utf8')).toEqual(
+    'yes',
+  )
 })

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -16,14 +16,14 @@ afterAll(async () => {
 it('creates an empty file', async () => {
   await api.create({ 'empty-file.txt': null })
 
-  expect(await api.read('empty-file.txt', 'utf8')).toEqual('')
+  expect(await api.readFile('empty-file.txt', 'utf8')).toEqual('')
 })
 
 it('creates a dot-file', async () => {
   await api.create({ '.eslintrc': null })
 
   expect(isDirectory(api.resolve('.eslintrc'))).toEqual(false)
-  expect(await api.read('.eslintrc', 'utf8')).toEqual('')
+  expect(await api.readFile('.eslintrc', 'utf8')).toEqual('')
 })
 
 it('creates a file with content', async () => {
@@ -31,7 +31,9 @@ it('creates a file with content', async () => {
     'inject-file.txt': 'arbitrary content',
   })
 
-  expect(await api.read('inject-file.txt', 'utf8')).toEqual('arbitrary content')
+  expect(await api.readFile('inject-file.txt', 'utf8')).toEqual(
+    'arbitrary content',
+  )
 })
 
 it('creates an empty directory', async () => {
@@ -51,6 +53,6 @@ it('creates a directory with files', async () => {
   })
 
   expect(isDirectory(api.resolve('inject-nested'))).toEqual(true)
-  expect(await api.read('inject-nested/1.txt', 'utf8')).toEqual('one')
-  expect(await api.read('inject-nested/2.txt', 'utf8')).toEqual('two')
+  expect(await api.readFile('inject-nested/1.txt', 'utf8')).toEqual('one')
+  expect(await api.readFile('inject-nested/2.txt', 'utf8')).toEqual('two')
 })

--- a/test/edit.test.ts
+++ b/test/edit.test.ts
@@ -20,16 +20,16 @@ afterAll(async () => {
 })
 
 it('edits an existing file', async () => {
-  expect(await api.read('file.txt', 'utf8')).toEqual('hello world')
+  expect(await api.readFile('file.txt', 'utf8')).toEqual('hello world')
 
   await api.edit('file.txt', 'hello universe')
-  expect(await api.read('file.txt', 'utf8')).toEqual('hello universe')
+  expect(await api.readFile('file.txt', 'utf8')).toEqual('hello universe')
 })
 
 it('edits a newly created file', async () => {
   await api.create({ 'edit-me.txt': 'some' })
   await api.edit('edit-me.txt', 'another')
-  expect(await api.read('edit-me.txt', 'utf8')).toEqual('another')
+  expect(await api.readFile('edit-me.txt', 'utf8')).toEqual('another')
 })
 
 it('throws an exception when editing a non-existing file', async () => {

--- a/test/readFile.test.ts
+++ b/test/readFile.test.ts
@@ -31,8 +31,14 @@ it('returns the stringified buffer given "encoding" argument', async () => {
   expect(await api.readFile('file.txt', 'utf8')).toEqual('hello world')
 })
 
-it('throws an exception when provided a directory path', async () => {
+it('throws an exception when ginve a directory path', async () => {
   await expect(() => api.readFile('directory')).rejects.toThrow(
     'Failed to read a file at "directory": given path points to a directory.',
+  )
+})
+
+it('throws an exception when given a non-existing path', async () => {
+  await expect(() => api.readFile('non-existing.txt')).rejects.toThrow(
+    'Failed to read a file at "non-existing.txt": given path does not exist.',
   )
 })

--- a/test/readFile.test.ts
+++ b/test/readFile.test.ts
@@ -22,17 +22,17 @@ afterAll(async () => {
 })
 
 it('returns the buffer of the given file', async () => {
-  expect(await api.read('file.txt')).toEqual(
+  expect(await api.readFile('file.txt')).toEqual(
     fs.readFileSync(api.resolve('file.txt')),
   )
 })
 
 it('returns the stringified buffer given "encoding" argument', async () => {
-  expect(await api.read('file.txt', 'utf8')).toEqual('hello world')
+  expect(await api.readFile('file.txt', 'utf8')).toEqual('hello world')
 })
 
 it('throws an exception when provided a directory path', async () => {
-  await expect(() => api.read('directory')).rejects.toThrow(
+  await expect(() => api.readFile('directory')).rejects.toThrow(
     'Failed to read a file at "directory": given path points to a directory.',
   )
 })

--- a/test/reset.test.ts
+++ b/test/reset.test.ts
@@ -24,7 +24,7 @@ it('removes the runtime paths', async () => {
   await api.reset()
   expect(fs.existsSync(api.resolve('one.txt'))).toEqual(false)
   expect(fs.existsSync(api.resolve('two.txt'))).toEqual(false)
-  expect(await api.read('file.txt', 'utf8')).toEqual('hello world')
+  expect(await api.readFile('file.txt', 'utf8')).toEqual('hello world')
 })
 
 it('removes multiple runtime paths', async () => {
@@ -37,15 +37,17 @@ it('removes multiple runtime paths', async () => {
   await api.reset()
   expect(fs.existsSync(api.resolve('abc.txt'))).toEqual(false)
   expect(fs.existsSync(api.resolve('def.txt'))).toEqual(false)
-  expect(await api.read('file.txt', 'utf8')).toEqual('hello world')
+  expect(await api.readFile('file.txt', 'utf8')).toEqual('hello world')
 })
 
 it('restores the initial paths edited on runtime', async () => {
   await api.edit('file.txt', 'welcome to the jungle')
-  expect(await api.read('file.txt', 'utf8')).toEqual('welcome to the jungle')
+  expect(await api.readFile('file.txt', 'utf8')).toEqual(
+    'welcome to the jungle',
+  )
 
   await api.reset()
-  expect(await api.read('file.txt', 'utf8')).toEqual('hello world')
+  expect(await api.readFile('file.txt', 'utf8')).toEqual('hello world')
 })
 
 it('restores the initial paths removed on runtime', async () => {
@@ -53,5 +55,5 @@ it('restores the initial paths removed on runtime', async () => {
   expect(fs.existsSync(api.resolve('file.txt'))).toEqual(false)
 
   await api.reset()
-  expect(await api.read('file.txt', 'utf8')).toEqual('hello world')
+  expect(await api.readFile('file.txt', 'utf8')).toEqual('hello world')
 })


### PR DESCRIPTION
- `read` -> `readFile`