### PR TITLE
feat: use "os.tmpdir" for relative paths in "rootDir"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ createTeardown({
 })
 ```
 
+> Providing a relative path to the `rootDir` creates the given path at the system's default directory for temporary files ([`os.tmpdir`](https://nodejs.org/api/os.html#ostmpdir)). Absolute paths are used as-is.
+
 ### `prepare(): Promise<string>`
 
 Creates files and directories specified in the `operations` of the teardown. Returns a `Promise` that resolves once all the operations have been executed.

--- a/src/fsTeardown.ts
+++ b/src/fsTeardown.ts
@@ -1,3 +1,4 @@
+import * as os from 'os'
 import * as path from 'path'
 import * as fs from 'fs-extra'
 import { invariant } from 'outvariant'
@@ -102,7 +103,7 @@ async function emitTree(
 export function createTeardown(options: CreateTeardownOptions): TeardownApi {
   const rootDir = path.isAbsolute(options.rootDir)
     ? options.rootDir
-    : path.relative(process.cwd(), options.rootDir)
+    : path.resolve(os.tmpdir(), options.rootDir)
 
   const api: TeardownApi = {
     async prepare() {

--- a/test/createTeardown/createTeardown.test.ts
+++ b/test/createTeardown/createTeardown.test.ts
@@ -1,5 +1,5 @@
-import { createTeardown } from '../src'
-import { isDirectory } from '../test/helpers/fs'
+import { createTeardown } from '../../src'
+import { isDirectory } from '../helpers/fs'
 
 const api = createTeardown({
   rootDir: 'tmp',

--- a/test/createTeardown/rootDir.test.ts
+++ b/test/createTeardown/rootDir.test.ts
@@ -1,0 +1,42 @@
+import * as os from 'os'
+import * as fs from 'fs'
+import * as path from 'path'
+import { createTeardown } from '../../src'
+
+it('creates a root directory in the OS tmpdir given a relative path', async () => {
+  const api = createTeardown({
+    rootDir: 'test-dir',
+    paths: {
+      'file.txt': null,
+    },
+  })
+
+  await api
+    .prepare()
+    .then(() => {
+      const absoluteFilePath = path.resolve(os.tmpdir(), 'test-dir/file.txt')
+
+      expect(api.resolve('file.txt')).toEqual(absoluteFilePath)
+      expect(fs.existsSync(absoluteFilePath)).toEqual(true)
+    })
+    .finally(api.cleanup)
+})
+
+it('creates a root directory at the given absolute path', async () => {
+  const api = createTeardown({
+    rootDir: path.resolve(__dirname, 'tmp'),
+    paths: {
+      'file.txt': null,
+    },
+  })
+
+  await api
+    .prepare()
+    .then(() => {
+      const absoluteFilePath = path.resolve(__dirname, 'tmp/file.txt')
+
+      expect(api.resolve('file.txt')).toEqual(absoluteFilePath)
+      expect(fs.existsSync(absoluteFilePath)).toEqual(true)
+    })
+    .finally(api.cleanup)
+})


### PR DESCRIPTION
Relative `rootDir` is now created in the system's default directory for temporary files (`os.tmpdir`). 